### PR TITLE
fix a bug in dynamic.py: display-quiz non-functional with a ref

### DIFF
--- a/jupyterquiz/dynamic.py
+++ b/jupyterquiz/dynamic.py
@@ -74,7 +74,7 @@ def display_quiz(ref, num=1_000_000, shuffle_questions=False, shuffle_answers=Tr
     elif isinstance(ref, str):
         if ref[0] == '#':
             script+=f'''var element=document.getElementById("{ref[1:]}");
-            var questions;
+            var questions{div_id};
             try {{
                questions{div_id}=JSON.parse(window.atob(element.innerHTML));
             }} catch(err) {{


### PR DESCRIPTION
In dynamic.py, the 'questions' var was initialized, but js attempted to write to 'questions{div_id}'. Since that var is not initialized, this led to a js error. The fix is to initialize 'questions{div_id}' instead.