### PR TITLE
Hide question div if question blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ JupyterQuiz supports a few options:
 * shuffle_answers = boolean, whether to shuffle answers for multiple-choice questions (default True)
 * preserve_responses = boolean, whether to output the user responses in a way that is preserved upon reload of the notebook (default False) -- see below
 
+### Quiz Formatting
+In addtion, it supports additional options for controlling the formatting of the quiz options.
+
+* `border_radius` = boolean, border radius of question boxes
+* `question_alignment` = string, alignment of question text (e.g., "left", "right)
+* `max_width` = int, max width of question boxes
+
+For more fine-grained formatting control of the question text, leaving the question field the empty string (`""`) will result in only the answers being displayed. This allows for custom question formatting such as including images, tables, more complex code examples, etc. Note that this feature works better for a single question quiz and may not work as well with shuffled quizzes or quiz questions selected at random.
+
 ## Preserving student responses
 
 **New as of version 2.0 (7/26/2022): There is now code to enable preserving student responses (for instance, for checking/grading their quizzes). If you want to use this functionality, please read this carefully!**

--- a/jupyterquiz/show_questions.js
+++ b/jupyterquiz/show_questions.js
@@ -76,18 +76,20 @@ function show_questions(json, mydiv) {
         iDiv.style.maxWidth  =max_width+"px";
         mydiv.appendChild(iDiv);
         // iDiv.innerHTML=qa.question;
+        
         var outerqDiv = document.createElement('div');
         outerqDiv.id = "OuterquizQn" + id + index;
-
-        iDiv.append(outerqDiv);
-
         // Create div to contain question part
         var qDiv = document.createElement('div');
         qDiv.id = "quizQn" + id + index;
-        //qDiv.textContent=qa.question;
-        qDiv.innerHTML = jaxify(qa.question);
+        
+        if (qa.question) {
+            iDiv.append(outerqDiv);
 
-        outerqDiv.append(qDiv);
+            //qDiv.textContent=qa.question;
+            qDiv.innerHTML = jaxify(qa.question);
+            outerqDiv.append(qDiv);
+        }
 
         // Create div for code inside question
         var codeDiv;


### PR DESCRIPTION
Hi again!

This is a fairly minor change, but might not be the right thing conceptually for the library. Open to feedback about if there are other things that can be changed to make this a bit clearer.

**Problem**: In many instances, the constraints of the formatting necessary to get the question text to work and look good inside the question card is quite difficult. Things like images, tables, and more complicated explanations for a problem just look pretty weird with a big orange background.

**Proposed Fix**: If the question is specified as the empty string, hide the question completely and only show the answer options. This allows users to specify the questions in whatever formatting/pictures/code/etc they want and then put the answer options right afterward. So users could now write more complex questions like the one below

<img width="1330" alt="image" src="https://user-images.githubusercontent.com/9054538/233744289-cde34241-aad4-4292-ab85-054a1c1554f7.png">

The specification for the question is as follows

```
questions = [
    {
        "question": "",
        "type": "multiple_choice",
        "answers": [
            {
                "answer": "True",
                "correct": True
            },
            {
                "answer": "False",
                "correct": False
            },
        ]
    }
]
display_quiz(questions)
```

**Uncertainties**: The code ended up being  really quick change, but I'm worried that might be a bigger change in the system and the documentation. In some sense "question" is still a required property, but I've added the semantics that if it is the empty string then the question isn't displayed.  Is that the right design here?

Feedback appreciated, but this feature would help me out a lot :) 