### PR TITLE
fix: change import for display

### DIFF
--- a/jupyterquiz/dynamic.py
+++ b/jupyterquiz/dynamic.py
@@ -1,5 +1,4 @@
-from IPython.display import display
-from IPython.core.display import Javascript, HTML
+from IPython.display import display, Javascript, HTML
 import string
 import random
 import importlib.resources

--- a/jupyterquiz/dynamic.py
+++ b/jupyterquiz/dynamic.py
@@ -1,4 +1,5 @@
-from IPython.core.display import display, Javascript, HTML
+from IPython.display import display
+from IPython.core.display import Javascript, HTML
 import string
 import random
 import importlib.resources


### PR DESCRIPTION
Importing display from IPython.core.display is deprecated since IPython 7.14.