### PR TITLE
Links

### DIFF
--- a/jupyterquiz/multiple_choice.js
+++ b/jupyterquiz/multiple_choice.js
@@ -175,9 +175,9 @@ function check_mc() {
         var numcorrect = fb.dataset.numcorrect;
         var answeredcorrect = fb.dataset.answeredcorrect;
         if (answeredcorrect >= 0) {
-            fb.textContent = feedback + " [" + answeredcorrect + "/" + numcorrect + "]";
+            fb.innerHTML = feedback + " [" + answeredcorrect + "/" + numcorrect + "]";
         } else {
-            fb.textContent = feedback + " [" + 0 + "/" + numcorrect + "]";
+            fb.innerHTML = feedback + " [" + 0 + "/" + numcorrect + "]";
         }
 
 

--- a/jupyterquiz/numeric.js
+++ b/jupyterquiz/numeric.js
@@ -25,7 +25,7 @@ function check_numeric(ths, event) {
 
         var fb = document.getElementById("fb" + id);
         fb.style.display = "none";
-        fb.textContent = "Incorrect -- try again.";
+        fb.innerHTML = "Incorrect -- try again.";
 
         var answers = JSON.parse(ths.dataset.answers);
         //console.log(answers);
@@ -209,7 +209,7 @@ function make_numeric(qa, outerqDiv, qDiv, aDiv, id) {
 
     var lab = document.createElement("label");
     lab.className = "InpLabel";
-    lab.textContent = "Type numeric answer here:";
+    lab.innerHTML = "Type numeric answer here:";
     aDiv.append(lab);
 
     var inp = document.createElement("input");

--- a/jupyterquiz/show_questions.js
+++ b/jupyterquiz/show_questions.js
@@ -33,8 +33,8 @@ function jaxify(string) {
     }
 
     // repace markdown style links with actual links
-    mystring = mystring.replace(/\[(.*?)\]\((.*?)\)/, '<a href="$2" target="_blank" class="Link">$1</a>');
     mystring = mystring.replace(/<(.*?)>/, '<a href="$1" target="_blank" class="Link">$1</a>');
+    mystring = mystring.replace(/\[(.*?)\]\((.*?)\)/, '<a href="$2" target="_blank" class="Link">$1</a>');
 
     //console.log(mystring);
     return mystring;

--- a/jupyterquiz/show_questions.js
+++ b/jupyterquiz/show_questions.js
@@ -32,6 +32,10 @@ function jaxify(string) {
         //console.log(mystring,", loc:",loc,", loc2:",loc2);
     }
 
+    // repace markdown style links with actual links
+    mystring = mystring.replace(/\[(.*?)\]\((.*?)\)/, '<a href="$2" target="_blank" class="Link">$1</a>');
+    mystring = mystring.replace(/<(.*?)>/, '<a href="$1" target="_blank" class="Link">$1</a>');
+
     //console.log(mystring);
     return mystring;
 }
@@ -219,5 +223,14 @@ if (typeof version == 'undefined') {
             }
         }
     }
+
+    // stop event propagation for the .Link class
+    var links = document.getElementsByClassName('Link')
+    for (var i = 0; i < links.length; i++) {
+        links[i].addEventListener('click', function(e){
+            e.stopPropagation();
+        });
+    }
+
     return false;
 }

--- a/jupyterquiz/styles.css
+++ b/jupyterquiz/styles.css
@@ -3,8 +3,8 @@
     margin-top: 15px;
     margin-left: auto;
     margin-right: auto;
-    margin-bottom: 15px;
-    padding-bottom: 4px;
+/*    margin-bottom: 15px;*/
+/*    padding-bottom: 4px;*/
     padding-top: 4px;
     line-height: 1.1;
     font-size: 16pt;
@@ -63,7 +63,7 @@
 .Feedback {
     font-size: 16pt;
     text-align: center;
-    min-height: 2em;
+/*    min-height: 2em;*/
 }
 
 .Input {


### PR DESCRIPTION
Hi @jmshea , I work with people from the [openCARP](https://opencarp.org) project, and we use jupyterquiz for some onboarding notebooks.

This PR adds the possibility to use external links in the quiz using the markdown syntax:

```plain
<https://example.com>
[Example site](https://example.com)
```

using some regexes similar to the handling of formulas. To make it work, I also changed `textContent` to `innerHtml` at several points in the code. I also removed some padding, which seemed unnecessary.

We are currently working with my fork, but we thought this might be a nice addition for everybody.